### PR TITLE
Use `provideDelegate` to simplify API. Resolves #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ class AppConfig: Config(configSources = listOf(LocalSource))
 ```kotlin
 class AppConfig: Config(configSources = listOf(LocalSource)) {
 
+	// The most simple config item, which uses the property name as a 
+	// key and sensible non-null default values
+	val someSimpleItem: Boolean by config()
+
     // Add a simple config item 
     val someItem: Boolean by config(
         key = "item_key",

--- a/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/extensions/ConfigExtensions.kt
+++ b/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/extensions/ConfigExtensions.kt
@@ -2,12 +2,12 @@ package nz.co.trademe.konfigure.android.extensions
 
 import android.content.Context
 import nz.co.trademe.konfigure.Config
-import nz.co.trademe.konfigure.api.ConfigDelegate
 import nz.co.trademe.konfigure.api.ConfigRegistry
 import nz.co.trademe.konfigure.android.ui.ConfigProvider
 import nz.co.trademe.konfigure.android.ui.DisplayMetadata
 import nz.co.trademe.konfigure.extensions.config
 import nz.co.trademe.konfigure.extensions.qualifiedGroup
+import nz.co.trademe.konfigure.api.ConfigRegistrar
 
 /**
  * Published extension function for simplifying the use of display metadata. Note, any consumer could implement similar extension
@@ -21,18 +21,18 @@ import nz.co.trademe.konfigure.extensions.qualifiedGroup
  */
 inline fun <reified T: Any> ConfigRegistry.config(
     group: String = qualifiedGroup ?: "Ungrouped",
-    title: String,
-    description: String,
-    key: String,
-    defaultValue: T
-): ConfigDelegate<T> = config(
+    title: String? = null,
+    description: String? = null,
+    key: String? = null,
+    defaultValue: T? = null
+): ConfigRegistrar<T> = config(
     key = key,
     defaultValue = defaultValue,
-    metadata = object: DisplayMetadata {
-        override val title: String = title
+    metadataProvider = { property -> object: DisplayMetadata {
+        override val title: String = title ?: property.name
         override val group: String = group
-        override val description: String = description
-    }
+        override val description: String = description ?: "Applies changes to the ${property.name} property"
+    }}
 )
 
 /**

--- a/konfigure/src/main/java/nz/co/trademe/konfigure/Config.kt
+++ b/konfigure/src/main/java/nz/co/trademe/konfigure/Config.kt
@@ -74,9 +74,15 @@ open class Config(
     val hasLocalOverrides: Boolean
         get() = overrideHandler.all.isNotEmpty()
 
-    override fun <T : Any> registerItem(item: ConfigItem<T>, itemClass: KClass<T>): ConfigDelegate<T> {
-        validateAndAddItem(item)
-        return ConfigDelegate(item, itemClass)
+    override fun <T: Any> registerItem(item: ConfigItem<T>) {
+        // Ensure the key of the item is unique
+        val duplicateKeyEntry = configItems.asSequence().find { it.key == item.key }
+
+        check(duplicateKeyEntry == null) {
+            "The key \"${item.key}\" already in use by item with metadata \"${duplicateKeyEntry?.metadata}\" - please choose another."
+        }
+
+        (configItems as MutableList).add(item)
     }
 
     override fun <T : Any> getValueOf(item: ConfigItem<T>, itemClass: KClass<T>): T {
@@ -139,17 +145,6 @@ open class Config(
         changeEvents.forEach {
             changeRelay.offer(it)
         }
-    }
-
-    private fun validateAndAddItem(item: ConfigItem<*>) {
-        // Ensure the key of the item is unique
-        val duplicateKeyEntry = configItems.asSequence().find { it.key == item.key }
-
-        check(duplicateKeyEntry == null) {
-            "The key \"${item.key}\" already in use by item with metadata \"${duplicateKeyEntry?.metadata}\" - please choose another."
-        }
-
-        (configItems as MutableList).add(item)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/konfigure/src/main/java/nz/co/trademe/konfigure/api/ConfigDelegate.kt
+++ b/konfigure/src/main/java/nz/co/trademe/konfigure/api/ConfigDelegate.kt
@@ -2,4 +2,7 @@ package nz.co.trademe.konfigure.api
 
 import kotlin.properties.ReadWriteProperty
 
+/**
+ * Interface simplifying [ReadWriteProperty] usage for config items
+ */
 interface ConfigDelegate<T: Any>: ReadWriteProperty<ConfigRegistry, T>

--- a/konfigure/src/main/java/nz/co/trademe/konfigure/api/ConfigDelegate.kt
+++ b/konfigure/src/main/java/nz/co/trademe/konfigure/api/ConfigDelegate.kt
@@ -1,21 +1,5 @@
 package nz.co.trademe.konfigure.api
 
-import nz.co.trademe.konfigure.model.ConfigItem
 import kotlin.properties.ReadWriteProperty
-import kotlin.reflect.KClass
-import kotlin.reflect.KProperty
 
-/**
- * Delegate used for handling config gets and sets. This is effectively internal.
- */
-class ConfigDelegate<T: Any>(
-    private val item: ConfigItem<T>,
-    private val itemClass: KClass<T>
-): ReadWriteProperty<ConfigRegistry, T> {
-
-    override fun getValue(thisRef: ConfigRegistry, property: KProperty<*>): T =
-        thisRef.getValueOf(item, itemClass)
-
-    override fun setValue(thisRef: ConfigRegistry, property: KProperty<*>, value: T) =
-        thisRef.setValueOf(item, itemClass, value)
-}
+interface ConfigDelegate<T: Any>: ReadWriteProperty<ConfigRegistry, T>

--- a/konfigure/src/main/java/nz/co/trademe/konfigure/api/ConfigRegistrar.kt
+++ b/konfigure/src/main/java/nz/co/trademe/konfigure/api/ConfigRegistrar.kt
@@ -1,0 +1,43 @@
+package nz.co.trademe.konfigure.api
+
+import nz.co.trademe.konfigure.extensions.MetadataProvider
+import nz.co.trademe.konfigure.internal.defaultValue
+import nz.co.trademe.konfigure.model.ConfigItem
+import nz.co.trademe.konfigure.model.ConfigMetadata
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+/**
+ * Interface which augments [ReadWriteProperty] to include delegate providing responsibilities
+ */
+class ConfigRegistrar<T: Any>(
+    private val key: String? = null,
+    private val defaultValue: T? = null,
+    private val metadataProvider: MetadataProvider? = null,
+    private val itemClass: KClass<T>
+) {
+
+    /**
+     * Provide config delegate. This checks input information and figures out sensible
+     * default values. It then instantiates the backing [ConfigItem] and registers the item with
+     * the parent [ConfigRegistry]
+     */
+    operator fun provideDelegate(thisRef: ConfigRegistry, property: KProperty<*>): ConfigDelegate<T> {
+        val key = key ?: property.name
+        val default = defaultValue ?: itemClass.defaultValue
+        val metadata = metadataProvider?.invoke(property) ?: object: ConfigMetadata {}
+
+        val configItem = ConfigItem(key, default, metadata)
+        thisRef.registerItem(configItem)
+
+        // Provide this class as the delegate
+        return object: ConfigDelegate<T> {
+            override fun getValue(thisRef: ConfigRegistry, property: KProperty<*>): T =
+                thisRef.getValueOf(configItem, itemClass)
+
+            override fun setValue(thisRef: ConfigRegistry, property: KProperty<*>, value: T) =
+                thisRef.setValueOf(configItem, itemClass, value)
+        }
+    }
+}

--- a/konfigure/src/main/java/nz/co/trademe/konfigure/api/ConfigRegistry.kt
+++ b/konfigure/src/main/java/nz/co/trademe/konfigure/api/ConfigRegistry.kt
@@ -16,7 +16,7 @@ interface ConfigRegistry {
     val group: String?
         get() = null
 
-    fun <T: Any> registerItem(item: ConfigItem<T>, itemClass: KClass<T>): ConfigDelegate<T>
+    fun <T: Any> registerItem(item: ConfigItem<T>)
 
     fun <T: Any> getValueOf(item: ConfigItem<T>, itemClass: KClass<T>): T
 

--- a/konfigure/src/main/java/nz/co/trademe/konfigure/extensions/ConfigExtensions.kt
+++ b/konfigure/src/main/java/nz/co/trademe/konfigure/extensions/ConfigExtensions.kt
@@ -1,9 +1,9 @@
 package nz.co.trademe.konfigure.extensions
 
-import nz.co.trademe.konfigure.api.ConfigDelegate
 import nz.co.trademe.konfigure.api.ConfigRegistry
-import nz.co.trademe.konfigure.model.ConfigItem
+import nz.co.trademe.konfigure.api.ConfigRegistrar
 import nz.co.trademe.konfigure.model.ConfigMetadata
+import kotlin.reflect.KProperty
 
 val ConfigRegistry.qualifiedGroup: String?
     get() {
@@ -16,10 +16,21 @@ val ConfigRegistry.qualifiedGroup: String?
         }
     }
 
+typealias MetadataProvider = (KProperty<*>) -> ConfigMetadata
+
+@Suppress("unused") // Unused suppression as it's used for extension function scoping
 inline fun <reified T : Any> ConfigRegistry.config(
-    key: String,
-    defaultValue: T,
-    metadata: ConfigMetadata = object: ConfigMetadata {}): ConfigDelegate<T> {
-    val configItem = ConfigItem(key, defaultValue, metadata)
-    return registerItem(configItem, T::class)
-}
+    key: String? = null,
+    defaultValue: T? = null,
+    metadata: ConfigMetadata? = null,
+    noinline metadataProvider: MetadataProvider? = when (metadata) {
+        null -> null
+        else -> {{ metadata }}
+    }
+): ConfigRegistrar<T> =
+    ConfigRegistrar(
+        key = key,
+        defaultValue = defaultValue,
+        metadataProvider = metadataProvider,
+        itemClass = T::class
+    )

--- a/konfigure/src/main/java/nz/co/trademe/konfigure/internal/DefaultValues.kt
+++ b/konfigure/src/main/java/nz/co/trademe/konfigure/internal/DefaultValues.kt
@@ -1,0 +1,21 @@
+package nz.co.trademe.konfigure.internal
+
+import kotlin.reflect.KClass
+
+/**
+ * Looks up a sensible default value for this class. Will throw an exception
+ * if applied to an unsupported class.
+ */
+@Suppress("UNCHECKED_CAST")
+internal val <T: Any> KClass<T>.defaultValue: T
+    get() {
+        return when (this) {
+            String::class -> "" as T
+            Boolean::class -> false as T
+            Int::class -> 0 as T
+            Long::class -> 0L as T
+            Float::class -> 0F as T
+            Double::class -> 0.0 as T
+            else -> throw IllegalArgumentException("Unsupported type $this")
+        }
+    }

--- a/sample/src/main/java/nz/co/trademe/konfigure/sample/config/AppConfig.kt
+++ b/sample/src/main/java/nz/co/trademe/konfigure/sample/config/AppConfig.kt
@@ -17,6 +17,8 @@ class AppConfig(context: Context): Config(
         description = "This is a test string"
     )
 
+    var anotherOne: String by config()
+
     val testSubConfig = TestSubConfig(parent = this)
 
     val restartableSubconfig = RestartableSubconfig(parent = this)

--- a/sample/src/main/java/nz/co/trademe/konfigure/sample/config/AppConfig.kt
+++ b/sample/src/main/java/nz/co/trademe/konfigure/sample/config/AppConfig.kt
@@ -17,6 +17,10 @@ class AppConfig(context: Context): Config(
         description = "This is a test string"
     )
 
+    /**
+     * We can define config items by defaulting the key to be the name of the property.
+     * In this case, this property will look up a String value keyed by "anotherOne"
+     */
     var anotherOne: String by config()
 
     val testSubConfig = TestSubConfig(parent = this)

--- a/sample/src/main/java/nz/co/trademe/konfigure/sample/examples/restart/RestartMetadata.kt
+++ b/sample/src/main/java/nz/co/trademe/konfigure/sample/examples/restart/RestartMetadata.kt
@@ -1,10 +1,10 @@
 package nz.co.trademe.konfigure.sample.examples.restart
 
 import nz.co.trademe.konfigure.android.ui.DisplayMetadata
-import nz.co.trademe.konfigure.api.ConfigDelegate
 import nz.co.trademe.konfigure.api.ConfigRegistry
 import nz.co.trademe.konfigure.extensions.config
 import nz.co.trademe.konfigure.extensions.qualifiedGroup
+import nz.co.trademe.konfigure.api.ConfigRegistrar
 
 /**
  * Custom metadata which expands on what's required to display and adds a flag around requiring restarts.
@@ -21,7 +21,7 @@ inline fun <reified T : Any> ConfigRegistry.config(
     defaultValue: T,
     title: String,
     description: String,
-    requiresRestart: Boolean = false): ConfigDelegate<T> = config(
+    requiresRestart: Boolean = false): ConfigRegistrar<T> = config(
     key = key,
     defaultValue = defaultValue,
     metadata = object: RestartMetadata {


### PR DESCRIPTION
As in title, this introduces the concept of a `ConfigRegistrar`, responsible for validating and registering items, as well as providing delegates. This has simplified the API somewhat, as with the inclusion of simple default values we can now define config items in a single line:
`val something: Boolean by config()`

This resolves #2.