### PR TITLE
Replace internal flow usage with channels. Resolves #4

### DIFF
--- a/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/view/ConfigPresenter.kt
+++ b/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/view/ConfigPresenter.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
@@ -28,8 +27,10 @@ internal class ConfigPresenter(
         search(searchTerm)
 
         launch {
-            config.changes
-                .collect { search(searchTerm) }
+            @Suppress("EXPERIMENTAL_API_USAGE")
+            for (change in config.changes.openSubscription()) {
+                search(searchTerm)
+            }
         }
     }
 

--- a/sample/src/main/java/nz/co/trademe/konfigure/sample/examples/restart/ConfigRestartActivity.kt
+++ b/sample/src/main/java/nz/co/trademe/konfigure/sample/examples/restart/ConfigRestartActivity.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -39,6 +40,7 @@ class ConfigRestartActivity : ConfigActivity() {
         // Observe changes and determine if a restart is required
         lifecycleScope.launch {
             applicationConfig.changes
+                .asFlow()
                 // Only keep items which have restart information, and require tracking
                 .filter { (it.metadata as? RestartMetadata)?.requiresRestart == true }
 


### PR DESCRIPTION
As in title. Config changes lead to an inherently hot stream of events. We should therefore not be using Flow within the library, but we should be providing examples of how it can be used to compose a cold stream with additional computation (see ConfigRestartActivity.kt)