### PR TITLE
[Android UI] Adds support for editing most `Number` types

### DIFF
--- a/konfigure-android/build.gradle
+++ b/konfigure-android/build.gradle
@@ -32,11 +32,11 @@ dependencies {
     api project(":konfigure")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3'
 
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "androidx.lifecycle:lifecycle-extensions:2.0.0"
+    implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
 }

--- a/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/adapter/ConfigAdapter.kt
+++ b/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/adapter/ConfigAdapter.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import nz.co.trademe.konfigure.android.ui.adapter.viewholder.BooleanConfigViewHolder
 import nz.co.trademe.konfigure.android.ui.adapter.viewholder.DividerViewHolder
 import nz.co.trademe.konfigure.android.ui.adapter.viewholder.HeaderViewHolder
-import nz.co.trademe.konfigure.android.ui.adapter.viewholder.LongConfigViewHolder
+import nz.co.trademe.konfigure.android.ui.adapter.viewholder.NumberConfigViewHolder
 import nz.co.trademe.konfigure.android.ui.adapter.viewholder.ResetToDefaultFooterViewHolder
 import nz.co.trademe.konfigure.android.ui.adapter.viewholder.StringConfigViewHolder
 
@@ -21,7 +21,7 @@ internal class ConfigAdapter(
     enum class ViewType {
         HEADER,
         STRING,
-        LONG,
+        NUMBER,
         BOOLEAN,
         DIVIDER,
         RESET_FOOTER
@@ -31,7 +31,7 @@ internal class ConfigAdapter(
         when (getItem(position)) {
             is ConfigAdapterModel.GroupHeader -> ViewType.HEADER
             is ConfigAdapterModel.StringConfig -> ViewType.STRING
-            is ConfigAdapterModel.LongConfig -> ViewType.LONG
+            is ConfigAdapterModel.NumberConfig<*> -> ViewType.NUMBER
             is ConfigAdapterModel.BooleanConfig -> ViewType.BOOLEAN
             is ConfigAdapterModel.ResetToDefaultFooter -> ViewType.RESET_FOOTER
             ConfigAdapterModel.Divider -> ViewType.DIVIDER
@@ -41,7 +41,7 @@ internal class ConfigAdapter(
         when (ViewType.values()[viewType]) {
             ViewType.HEADER -> HeaderViewHolder(parent)
             ViewType.STRING -> StringConfigViewHolder(parent)
-            ViewType.LONG -> LongConfigViewHolder(parent)
+            ViewType.NUMBER -> NumberConfigViewHolder(parent)
             ViewType.BOOLEAN -> BooleanConfigViewHolder(parent)
             ViewType.DIVIDER -> DividerViewHolder(parent)
             ViewType.RESET_FOOTER -> ResetToDefaultFooterViewHolder(parent)
@@ -56,8 +56,8 @@ internal class ConfigAdapter(
                 val model = getItem(position) as ConfigAdapterModel.StringConfig
                 holder.bind(model)
             }
-            is LongConfigViewHolder -> {
-                val model = getItem(position) as ConfigAdapterModel.LongConfig
+            is NumberConfigViewHolder -> {
+                val model = getItem(position) as ConfigAdapterModel.NumberConfig<*>
                 holder.bind(model)
             }
             is BooleanConfigViewHolder -> {

--- a/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/adapter/ConfigAdapterModel.kt
+++ b/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/adapter/ConfigAdapterModel.kt
@@ -23,9 +23,9 @@ internal sealed class ConfigAdapterModel(val key: String? = null) {
         val metadata: DisplayMetadata
     ) : ConfigAdapterModel(key = item.key)
 
-    data class LongConfig(
-        val item: ConfigItem<Long>,
-        val value: Long,
+    data class NumberConfig<T: Number>(
+        val item: ConfigItem<T>,
+        val value: T,
         val isModified: Boolean,
         val metadata: DisplayMetadata
     ) : ConfigAdapterModel(key = item.key)

--- a/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/adapter/viewholder/NumberConfigViewHolder.kt
+++ b/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/adapter/viewholder/NumberConfigViewHolder.kt
@@ -2,17 +2,16 @@ package nz.co.trademe.konfigure.android.ui.adapter.viewholder
 
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.view_holder_long.*
+import kotlinx.android.synthetic.main.view_holder_number.*
 import nz.co.trademe.konfigure.android.R
 import nz.co.trademe.konfigure.android.ui.adapter.ConfigAdapterModel
 import nz.co.trademe.konfigure.android.ui.dialog.EditConfigDialogFragment
-import nz.co.trademe.konfigure.android.ui.dialog.EditConfigType
 
-internal class LongConfigViewHolder(
+internal class NumberConfigViewHolder(
     parent: ViewGroup
-) : BaseViewHolder(parent.inflate(R.layout.view_holder_long)) {
+) : BaseViewHolder(parent.inflate(R.layout.view_holder_number)) {
 
-    fun bind(model: ConfigAdapterModel.LongConfig) {
+    fun bind(model: ConfigAdapterModel.NumberConfig<*>) {
         titleTextView.text = model.metadata.title
         titleTextView.showAsModified(model.isModified)
 
@@ -24,7 +23,6 @@ internal class LongConfigViewHolder(
         itemView.setOnClickListener {
             EditConfigDialogFragment.start(
                     model.item,
-                    EditConfigType.NUMBER,
                     model.value.toString(),
                     (itemView.context as AppCompatActivity).supportFragmentManager)
         }

--- a/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/adapter/viewholder/StringConfigViewHolder.kt
+++ b/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/adapter/viewholder/StringConfigViewHolder.kt
@@ -1,11 +1,11 @@
 package nz.co.trademe.konfigure.android.ui.adapter.viewholder
 
+import android.annotation.SuppressLint
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.view_holder_string.*
 import nz.co.trademe.konfigure.android.R
 import nz.co.trademe.konfigure.android.ui.adapter.ConfigAdapterModel
 import nz.co.trademe.konfigure.android.ui.dialog.EditConfigDialogFragment
-import nz.co.trademe.konfigure.android.ui.dialog.EditConfigType
 import nz.co.trademe.konfigure.android.ui.ConfigActivity
 
 internal class StringConfigViewHolder(
@@ -18,13 +18,13 @@ internal class StringConfigViewHolder(
 
         descriptionTextView.text = model.metadata.description
 
-        currentValueTextView.text = model.value
+        @SuppressLint("SetTextI18n")
+        currentValueTextView.text = "\"${model.value}\""
         currentValueTextView.applyMonospaceFont()
 
         itemView.setOnClickListener {
             EditConfigDialogFragment.start(
                     model.item,
-                    EditConfigType.STRING,
                     model.value,
                     (itemView.context as ConfigActivity).supportFragmentManager)
         }

--- a/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/dialog/EditConfigType.kt
+++ b/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/dialog/EditConfigType.kt
@@ -1,6 +1,0 @@
-package nz.co.trademe.konfigure.android.ui.dialog
-
-internal enum class EditConfigType {
-    STRING,
-    NUMBER
-}

--- a/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/view/ConfigPresenter.kt
+++ b/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/view/ConfigPresenter.kt
@@ -177,12 +177,10 @@ internal class ConfigPresenter(
     @Suppress("UNCHECKED_CAST")
     private fun ConfigItem<*>.toModel(): ConfigAdapterModel =
         when (defaultValue) {
-            is Long -> ConfigAdapterModel.LongConfig(
-                item = this as ConfigItem<Long>,
-                value = config.getValueOf(this, Long::class),
-                isModified = config.modifiedItems.contains(this),
-                metadata = metadata as DisplayMetadata
-            )
+            is Int -> toNumberModel<Int>()
+            is Long -> toNumberModel<Long>()
+            is Float -> toNumberModel<Float>()
+            is Double -> toNumberModel<Double>()
             is Boolean -> ConfigAdapterModel.BooleanConfig(
                 item = this as ConfigItem<Boolean>,
                 value = config.getValueOf(this, Boolean::class),
@@ -197,6 +195,14 @@ internal class ConfigPresenter(
             )
             else -> throw IllegalArgumentException("Unknown type $this")
         }
+
+    @Suppress("UNCHECKED_CAST")
+    private inline fun <reified T: Number> ConfigItem<*>.toNumberModel(): ConfigAdapterModel.NumberConfig<T> = ConfigAdapterModel.NumberConfig(
+        item = this as ConfigItem<T>,
+        value = config.getValueOf(this, T::class),
+        isModified = config.modifiedItems.contains(this),
+        metadata = metadata as DisplayMetadata
+    )
 
     private fun List<ConfigItem<*>>.mapToModel(): Array<ConfigAdapterModel> =
         map { it.toModel() }.toTypedArray()

--- a/konfigure-android/src/main/res/layout/view_holder_boolean.xml
+++ b/konfigure-android/src/main/res/layout/view_holder_boolean.xml
@@ -24,7 +24,7 @@
             android:id="@+id/titleTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
             android:drawablePadding="4dp"
             tools:text="Boolean Config" />
 
@@ -32,7 +32,7 @@
             android:id="@+id/descriptionTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
             tools:text="This value represents some boolean config which we can change the value of." />
     </LinearLayout>
 

--- a/konfigure-android/src/main/res/layout/view_holder_header.xml
+++ b/konfigure-android/src/main/res/layout/view_holder_header.xml
@@ -17,7 +17,7 @@
         android:layout_marginBottom="8dp"
         android:maxLines="1"
         android:textColor="?attr/colorAccent"
-        android:textAppearance="@style/Base.TextAppearance.AppCompat.Body2"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
         tools:text="Navigation" />
 
 </FrameLayout>

--- a/konfigure-android/src/main/res/layout/view_holder_number.xml
+++ b/konfigure-android/src/main/res/layout/view_holder_number.xml
@@ -14,7 +14,8 @@
         android:id="@+id/titleTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:drawablePadding="4dp"
         tools:text="Long Config" />
 
     <TextView
@@ -22,7 +23,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
         tools:text="This value represents a `Long` typed config item." />
 
     <TextView
@@ -31,7 +32,7 @@
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:maxLines="1"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:textColor="@color/black_54pc"
         tools:text="1234" />
 

--- a/konfigure-android/src/main/res/layout/view_holder_string.xml
+++ b/konfigure-android/src/main/res/layout/view_holder_string.xml
@@ -14,7 +14,7 @@
         android:id="@+id/titleTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:drawablePadding="4dp"
         tools:text="String config" />
 
@@ -23,7 +23,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="4dp"
-        android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
         tools:text="This config item represents something string related" />
 
     <TextView
@@ -32,7 +32,7 @@
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:maxLines="1"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:textColor="@color/black_54pc"
         tools:text="Current value: '{'0001': [4, 10]}'" />
 

--- a/konfigure-android/src/main/res/values/styles.xml
+++ b/konfigure-android/src/main/res/values/styles.xml
@@ -9,9 +9,6 @@
     </style>
 
     <style name="Theme.Config.NoActionBar" parent="Theme.MaterialComponents.Light.NoActionBar">
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
         <item name="android:windowBackground">@color/white</item>
 
         <item name="toolbarStyle">@style/MainToolbar</item>

--- a/konfigure/src/main/java/nz/co/trademe/konfigure/Config.kt
+++ b/konfigure/src/main/java/nz/co/trademe/konfigure/Config.kt
@@ -1,9 +1,6 @@
 package nz.co.trademe.konfigure
 
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
-import kotlinx.coroutines.channels.broadcast
-import nz.co.trademe.konfigure.api.ConfigDelegate
 import nz.co.trademe.konfigure.api.ConfigRegistry
 import nz.co.trademe.konfigure.api.ConfigSource
 import nz.co.trademe.konfigure.api.OverrideHandler

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -22,6 +22,11 @@
         </activity>
 
         <activity
+            android:name="nz.co.trademe.konfigure.android.ui.ConfigActivity"
+            android:theme="@style/AppTheme.NoActionBar"
+            tools:replace="android:theme"/>
+
+        <activity
             android:name=".examples.restart.ConfigRestartActivity"
             android:theme="@style/AppTheme.NoActionBar" />
 

--- a/sample/src/main/java/nz/co/trademe/konfigure/sample/config/AppConfig.kt
+++ b/sample/src/main/java/nz/co/trademe/konfigure/sample/config/AppConfig.kt
@@ -21,6 +21,14 @@ class AppConfig(context: Context): Config(
         description = "This is a test string"
     )
 
+
+    val theMeaningOfLife: Int by config(
+        key = "life_meaning",
+        defaultValue = 42,
+        title = "The Meaning of Life",
+        description = "As in title. Changing this has undefined output."
+    )
+
     /**
      * We can define config items by defaulting the key to be the name of the property.
      * In this case, this property will look up a String value keyed by "anotherOne"


### PR DESCRIPTION
As in title, this pull request allows editing of number types. These types were always supported by the core Konfigure library, but the UI hadn't been changed to support this.