### PR TITLE
MP-965 Add trigger for search after filter added

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -1,4 +1,4 @@
-ext.version = "1.3.0"
+ext.version = "1.3.1"
 ext.group = "nz.co.trademe.konfigure"
 ext.repo = "konfigure"
 ext.org = "trademe"

--- a/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/view/ConfigView.kt
+++ b/konfigure-android/src/main/java/nz/co/trademe/konfigure/android/ui/view/ConfigView.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext


### PR DESCRIPTION
`searchTermRelay` was unable to re-trigger the search after new search filter added if the search term is the same. So adding an additional searchTrigger specifically for such purpose